### PR TITLE
feat: deprecate Community.cluster property

### DIFF
--- a/api-schema.graphql
+++ b/api-schema.graphql
@@ -16,7 +16,6 @@ input AdminCreateBotInput {
 
 input AdminCreateCommunityInput {
   avatarUrl: String
-  cluster: NetworkCluster!
   description: String
   discordUrl: String
   githubUrl: String
@@ -264,7 +263,6 @@ enum BotStatus {
 
 type Community {
   avatarUrl: String
-  cluster: NetworkCluster!
   createdAt: DateTime
   description: String
   discordUrl: String
@@ -814,7 +812,6 @@ input UserCreateBotInput {
 
 input UserCreateCommunityInput {
   avatarUrl: String
-  cluster: NetworkCluster!
   description: String
   discordUrl: String
   githubUrl: String

--- a/apps/api-e2e/src/api/api-community-admin-feature.spec.ts
+++ b/apps/api-e2e/src/api/api-community-admin-feature.spec.ts
@@ -3,11 +3,9 @@ import {
   AdminFindManyCommunityInput,
   AdminUpdateCommunityInput,
   Community,
-  NetworkCluster,
 } from '@pubkey-link/sdk'
 import { getAliceCookie, getBobCookie, sdk, uniqueId } from '../support'
 
-const defaultCluster = NetworkCluster.SolanaMainnet
 describe('api-community-feature', () => {
   describe('api-community-admin-resolver', () => {
     const communityName = uniqueId('acme-community')
@@ -21,7 +19,6 @@ describe('api-community-feature', () => {
       const created = await sdk.adminCreateCommunity(
         {
           input: {
-            cluster: defaultCluster,
             name: communityName,
           },
         },
@@ -33,7 +30,6 @@ describe('api-community-feature', () => {
     describe('authorized', () => {
       it('should create a community', async () => {
         const input: AdminCreateCommunityInput = {
-          cluster: defaultCluster,
           name: uniqueId('community'),
         }
 
@@ -48,7 +44,6 @@ describe('api-community-feature', () => {
 
       it('should update a community', async () => {
         const createInput: AdminCreateCommunityInput = {
-          cluster: defaultCluster,
           name: uniqueId('community'),
         }
         const createdRes = await sdk.adminCreateCommunity({ input: createInput }, { cookie: alice })
@@ -64,7 +59,7 @@ describe('api-community-feature', () => {
       })
 
       it('should find a list of communities (find all)', async () => {
-        const createInput: AdminCreateCommunityInput = { cluster: defaultCluster, name: uniqueId('community') }
+        const createInput: AdminCreateCommunityInput = { name: uniqueId('community') }
         const createdRes = await sdk.adminCreateCommunity({ input: createInput }, { cookie: alice })
         const communityId = createdRes.data.created.id
 
@@ -81,7 +76,7 @@ describe('api-community-feature', () => {
       })
 
       it('should find a list of communities (find new one)', async () => {
-        const createInput: AdminCreateCommunityInput = { cluster: defaultCluster, name: uniqueId('community') }
+        const createInput: AdminCreateCommunityInput = { name: uniqueId('community') }
         const createdRes = await sdk.adminCreateCommunity({ input: createInput }, { cookie: alice })
         const communityId = createdRes.data.created.id
 
@@ -97,7 +92,7 @@ describe('api-community-feature', () => {
       })
 
       it('should find a community by id', async () => {
-        const createInput: AdminCreateCommunityInput = { cluster: defaultCluster, name: uniqueId('community') }
+        const createInput: AdminCreateCommunityInput = { name: uniqueId('community') }
         const createdRes = await sdk.adminCreateCommunity({ input: createInput }, { cookie: alice })
         const communityId = createdRes.data.created.id
 
@@ -107,7 +102,7 @@ describe('api-community-feature', () => {
       })
 
       it('should delete a community', async () => {
-        const createInput: AdminCreateCommunityInput = { cluster: defaultCluster, name: uniqueId('community') }
+        const createInput: AdminCreateCommunityInput = { name: uniqueId('community') }
         const createdRes = await sdk.adminCreateCommunity({ input: createInput }, { cookie: alice })
         const communityId = createdRes.data.created.id
 
@@ -124,7 +119,7 @@ describe('api-community-feature', () => {
     describe('unauthorized', () => {
       it('should not create a community', async () => {
         expect.assertions(1)
-        const input: AdminCreateCommunityInput = { cluster: defaultCluster, name: uniqueId('community') }
+        const input: AdminCreateCommunityInput = { name: uniqueId('community') }
 
         try {
           await sdk.adminCreateCommunity({ input }, { cookie: bob })

--- a/apps/api-e2e/src/api/api-community-user-feature.spec.ts
+++ b/apps/api-e2e/src/api/api-community-user-feature.spec.ts
@@ -21,7 +21,6 @@ xdescribe('api-community-feature', () => {
       const created = await sdk.userCreateCommunity(
         {
           input: {
-            cluster: defaultCluster,
             name: communityName,
           },
         },
@@ -33,7 +32,6 @@ xdescribe('api-community-feature', () => {
     describe('authorized', () => {
       it('should create a community', async () => {
         const input: UserCreateCommunityInput = {
-          cluster: defaultCluster,
           name: uniqueId('community'),
         }
 
@@ -48,7 +46,6 @@ xdescribe('api-community-feature', () => {
 
       it('should update a community', async () => {
         const createInput: UserCreateCommunityInput = {
-          cluster: defaultCluster,
           name: uniqueId('community'),
         }
         const createdRes = await sdk.userCreateCommunity({ input: createInput }, { cookie: alice })
@@ -65,7 +62,6 @@ xdescribe('api-community-feature', () => {
 
       it('should find a list of communities (find all)', async () => {
         const createInput: UserCreateCommunityInput = {
-          cluster: defaultCluster,
           name: uniqueId('community'),
         }
         const createdRes = await sdk.userCreateCommunity({ input: createInput }, { cookie: alice })
@@ -83,7 +79,6 @@ xdescribe('api-community-feature', () => {
 
       it('should find a list of communities (find new one)', async () => {
         const createInput: UserCreateCommunityInput = {
-          cluster: defaultCluster,
           name: uniqueId('community'),
         }
         const createdRes = await sdk.userCreateCommunity({ input: createInput }, { cookie: alice })
@@ -102,7 +97,6 @@ xdescribe('api-community-feature', () => {
 
       it('should find a community by id', async () => {
         const createInput: UserCreateCommunityInput = {
-          cluster: defaultCluster,
           name: uniqueId('community'),
         }
         const createdRes = await sdk.userCreateCommunity({ input: createInput }, { cookie: alice })
@@ -115,7 +109,6 @@ xdescribe('api-community-feature', () => {
 
       it('should delete a community', async () => {
         const createInput: UserCreateCommunityInput = {
-          cluster: defaultCluster,
           name: uniqueId('community'),
         }
         const createdRes = await sdk.userCreateCommunity({ input: createInput }, { cookie: alice })
@@ -135,7 +128,6 @@ xdescribe('api-community-feature', () => {
       it('should not create a community', async () => {
         expect.assertions(1)
         const input: UserCreateCommunityInput = {
-          cluster: defaultCluster,
           name: uniqueId('community'),
         }
 

--- a/apps/cli/src/data-access/command-service.ts
+++ b/apps/cli/src/data-access/command-service.ts
@@ -52,8 +52,8 @@ export class CommandService {
       return
     }
     console.log(`Found ${res.data.paging.meta.totalCount} communities`)
-    for (const { id, name, description, cluster } of res.data.paging.data) {
-      console.log(`- [${cluster}] [${id}] ${name} - ${description}`)
+    for (const { id, name, description } of res.data.paging.data) {
+      console.log(`- [${id}] ${name} - ${description}`)
     }
   }
 

--- a/libs/api/bot/data-access/src/lib/api-bot-instances.service.ts
+++ b/libs/api/bot/data-access/src/lib/api-bot-instances.service.ts
@@ -511,7 +511,7 @@ export class ApiBotInstancesService {
     await discordBot.sendChannel(botServer.botChannel, {
       embeds: [
         {
-          title: `Configuration for ${discordBot.client?.user?.username} in ${bot.community.name} (${bot.community.cluster})`,
+          title: `Configuration for ${discordBot.client?.user?.username} in ${bot.community.name}`,
           fields: [
             { name: 'Requester', value: `<@${identity.providerId}>` },
             { name: `Bot`, value: `<@${discordBot.client?.user?.id}>` },

--- a/libs/api/community/data-access/src/lib/api-community-data.service.ts
+++ b/libs/api/community/data-access/src/lib/api-community-data.service.ts
@@ -9,7 +9,6 @@ export class ApiCommunityDataService {
 
   async create(userId: string, input: Prisma.CommunityCreateInput) {
     this.core.config.ensureFeature(AppFeature.CommunityCreate)
-    await this.core.ensureNetworkCluster(input.cluster)
     const created = await this.core.createCommunity({ userId, input })
     await this.core.logInfo(`[${created.id}] Community created`, { userId, communityId: created.id })
     return created

--- a/libs/api/community/data-access/src/lib/dto/admin-create-community.input.ts
+++ b/libs/api/community/data-access/src/lib/dto/admin-create-community.input.ts
@@ -1,10 +1,7 @@
 import { Field, InputType } from '@nestjs/graphql'
-import { NetworkCluster } from '@pubkey-link/api-network-data-access'
 
 @InputType()
 export class AdminCreateCommunityInput {
-  @Field(() => NetworkCluster)
-  cluster!: NetworkCluster
   @Field()
   name!: string
   @Field({ nullable: true })

--- a/libs/api/community/data-access/src/lib/dto/user-create-community.input.ts
+++ b/libs/api/community/data-access/src/lib/dto/user-create-community.input.ts
@@ -1,10 +1,7 @@
 import { Field, InputType } from '@nestjs/graphql'
-import { NetworkCluster } from '@pubkey-link/api-network-data-access'
 
 @InputType()
 export class UserCreateCommunityInput {
-  @Field(() => NetworkCluster)
-  cluster!: NetworkCluster
   @Field()
   name!: string
   @Field({ nullable: true })

--- a/libs/api/community/data-access/src/lib/entity/community.entity.ts
+++ b/libs/api/community/data-access/src/lib/entity/community.entity.ts
@@ -1,6 +1,5 @@
 import { Field, ObjectType } from '@nestjs/graphql'
 import { PagingResponse } from '@pubkey-link/api-core-data-access'
-import { NetworkCluster } from '@pubkey-link/api-network-data-access'
 import { Role } from '@pubkey-link/api-role-data-access'
 
 @ObjectType()
@@ -31,8 +30,6 @@ export class Community {
   twitterUrl?: string | null
   @Field({ nullable: true })
   telegramUrl?: string | null
-  @Field(() => NetworkCluster)
-  cluster!: NetworkCluster
   @Field(() => [Role], { nullable: true })
   roles?: Role[]
 }

--- a/libs/api/community/data-access/src/lib/provision/api-community-provision-data.ts
+++ b/libs/api/community/data-access/src/lib/provision/api-community-provision-data.ts
@@ -152,7 +152,6 @@ const PK_BOT: Prisma.BotCreateWithoutCommunityInput = {
 
 export const provisionCommunities: Prisma.CommunityCreateInput[] = [
   {
-    cluster: NetworkCluster.SolanaCustom,
     name: 'localhost',
     featured: true,
     enableSync: true,
@@ -170,7 +169,6 @@ export const provisionCommunities: Prisma.CommunityCreateInput[] = [
     },
   },
   {
-    cluster,
     name: 'PubKey',
     featured: true,
     enableSync: true,
@@ -232,7 +230,6 @@ export const provisionCommunities: Prisma.CommunityCreateInput[] = [
     },
   },
   {
-    cluster,
     id: 'deanslist',
     name: "Dean's List",
     featured: true,
@@ -278,7 +275,6 @@ export const provisionCommunities: Prisma.CommunityCreateInput[] = [
     },
   },
   {
-    cluster,
     name: 'Marinade',
     description: 'A DAO with a staking protocol built on Solana',
     avatarUrl: 'https://avatars.githubusercontent.com/u/81361338?v=4',
@@ -303,7 +299,6 @@ export const provisionCommunities: Prisma.CommunityCreateInput[] = [
     },
   },
   {
-    cluster,
     id: 'legends-of-sol',
     name: 'Legends of SOL',
     featured: true,

--- a/libs/api/community/data-access/src/lib/provision/api-community-provision.service.ts
+++ b/libs/api/community/data-access/src/lib/provision/api-community-provision.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
-import { Network, NetworkCluster, Prisma } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import { ApiCoreService, slugifyId } from '@pubkey-link/api-core-data-access'
 import { EVENT_NETWORKS_PROVISIONED } from '@pubkey-link/api-network-data-access'
 import { EVENT_COMMUNITIES_PROVISIONED } from '../api-community.events'
@@ -13,19 +13,18 @@ export class ApiCommunityProvisionService {
   constructor(private readonly core: ApiCoreService) {}
 
   @OnEvent(EVENT_NETWORKS_PROVISIONED)
-  async onApplicationStarted(networks: Network[]) {
+  async onApplicationStarted() {
     if (this.core.config.databaseProvision) {
-      await this.provisionCommunities({ clusters: networks.map((n) => n.cluster) })
+      await this.provisionCommunities()
       this.logger.verbose(`Provisioned communities`)
     }
   }
 
-  private async provisionCommunities({ clusters }: { clusters: NetworkCluster[] }) {
-    const communities = provisionCommunities.filter((c) => clusters.includes(c.cluster))
-    if (!communities) {
+  private async provisionCommunities() {
+    if (!provisionCommunities.length) {
       return
     }
-    await Promise.all(communities.map((community) => this.provisionCommunity(community)))
+    await Promise.all(provisionCommunities.map((community) => this.provisionCommunity(community)))
     this.core.eventEmitter.emit(EVENT_COMMUNITIES_PROVISIONED)
   }
 

--- a/libs/api/network-token/data-access/src/lib/api-network-token-data.service.ts
+++ b/libs/api/network-token/data-access/src/lib/api-network-token-data.service.ts
@@ -54,7 +54,7 @@ export class ApiNetworkTokenDataService {
           network: { connect: { cluster: network.cluster } },
           type: NetworkTokenType.Validator,
           account: hash,
-          name: `Solana Genesis`,
+          name: `${network.cluster.replace('Solana', 'Solana ')} Genesis`,
           program: SystemProgram.programId.toBase58(),
         }
 

--- a/libs/api/role/data-access/src/lib/entity/role-condition.entity.ts
+++ b/libs/api/role/data-access/src/lib/entity/role-condition.entity.ts
@@ -24,7 +24,7 @@ export class RoleCondition {
   @Field(() => GraphQLJSON, { nullable: true })
   filters?: Prisma.JsonValue | null
   @Field({ nullable: true })
-  token?: NetworkToken | null
+  token!: NetworkToken
   role?: Role | null
   @Field({ nullable: true })
   tokenId?: string | null

--- a/libs/sdk/src/generated/graphql-sdk.ts
+++ b/libs/sdk/src/generated/graphql-sdk.ts
@@ -38,7 +38,6 @@ export type AdminCreateBotInput = {
 
 export type AdminCreateCommunityInput = {
   avatarUrl?: InputMaybe<Scalars['String']['input']>
-  cluster: NetworkCluster
   description?: InputMaybe<Scalars['String']['input']>
   discordUrl?: InputMaybe<Scalars['String']['input']>
   githubUrl?: InputMaybe<Scalars['String']['input']>
@@ -292,7 +291,6 @@ export enum BotStatus {
 export type Community = {
   __typename?: 'Community'
   avatarUrl?: Maybe<Scalars['String']['output']>
-  cluster: NetworkCluster
   createdAt?: Maybe<Scalars['DateTime']['output']>
   description?: Maybe<Scalars['String']['output']>
   discordUrl?: Maybe<Scalars['String']['output']>
@@ -1396,7 +1394,6 @@ export type UserCreateBotInput = {
 
 export type UserCreateCommunityInput = {
   avatarUrl?: InputMaybe<Scalars['String']['input']>
-  cluster: NetworkCluster
   description?: InputMaybe<Scalars['String']['input']>
   discordUrl?: InputMaybe<Scalars['String']['input']>
   githubUrl?: InputMaybe<Scalars['String']['input']>
@@ -3478,7 +3475,6 @@ export type CommunityDetailsFragment = {
   twitterUrl?: string | null
   telegramUrl?: string | null
   updatedAt?: Date | null
-  cluster: NetworkCluster
 }
 
 export type AdminFindManyCommunityQueryVariables = Exact<{
@@ -3504,7 +3500,6 @@ export type AdminFindManyCommunityQuery = {
       twitterUrl?: string | null
       telegramUrl?: string | null
       updatedAt?: Date | null
-      cluster: NetworkCluster
     }>
     meta: {
       __typename?: 'PagingMeta'
@@ -3540,7 +3535,6 @@ export type AdminFindOneCommunityQuery = {
     twitterUrl?: string | null
     telegramUrl?: string | null
     updatedAt?: Date | null
-    cluster: NetworkCluster
   } | null
 }
 
@@ -3565,7 +3559,6 @@ export type AdminCreateCommunityMutation = {
     twitterUrl?: string | null
     telegramUrl?: string | null
     updatedAt?: Date | null
-    cluster: NetworkCluster
   } | null
 }
 
@@ -3591,7 +3584,6 @@ export type AdminUpdateCommunityMutation = {
     twitterUrl?: string | null
     telegramUrl?: string | null
     updatedAt?: Date | null
-    cluster: NetworkCluster
   } | null
 }
 
@@ -3620,7 +3612,6 @@ export type AnonGetCommunitiesQuery = {
     twitterUrl?: string | null
     telegramUrl?: string | null
     updatedAt?: Date | null
-    cluster: NetworkCluster
     roles?: Array<{
       __typename?: 'Role'
       createdAt?: Date | null
@@ -3743,7 +3734,6 @@ export type UserGetCommunitiesQuery = {
     twitterUrl?: string | null
     telegramUrl?: string | null
     updatedAt?: Date | null
-    cluster: NetworkCluster
     roles?: Array<{
       __typename?: 'Role'
       createdAt?: Date | null
@@ -3868,7 +3858,6 @@ export type UserFindManyCommunityQuery = {
       twitterUrl?: string | null
       telegramUrl?: string | null
       updatedAt?: Date | null
-      cluster: NetworkCluster
       roles?: Array<{
         __typename?: 'Role'
         createdAt?: Date | null
@@ -4002,7 +3991,6 @@ export type UserFindOneCommunityQuery = {
     twitterUrl?: string | null
     telegramUrl?: string | null
     updatedAt?: Date | null
-    cluster: NetworkCluster
   } | null
 }
 
@@ -4027,7 +4015,6 @@ export type UserCreateCommunityMutation = {
     twitterUrl?: string | null
     telegramUrl?: string | null
     updatedAt?: Date | null
-    cluster: NetworkCluster
   } | null
 }
 
@@ -4053,7 +4040,6 @@ export type UserUpdateCommunityMutation = {
     twitterUrl?: string | null
     telegramUrl?: string | null
     updatedAt?: Date | null
-    cluster: NetworkCluster
   } | null
 }
 
@@ -8566,7 +8552,6 @@ export const CommunityDetailsFragmentDoc = gql`
     twitterUrl
     telegramUrl
     updatedAt
-    cluster
   }
 `
 export const AppConfigDetailsFragmentDoc = gql`
@@ -13165,7 +13150,6 @@ export function AdminCreateBotInputSchema(): z.ZodObject<Properties<AdminCreateB
 export function AdminCreateCommunityInputSchema(): z.ZodObject<Properties<AdminCreateCommunityInput>> {
   return z.object({
     avatarUrl: z.string().nullish(),
-    cluster: NetworkClusterSchema,
     description: z.string().nullish(),
     discordUrl: z.string().nullish(),
     githubUrl: z.string().nullish(),
@@ -13427,7 +13411,6 @@ export function UserCreateBotInputSchema(): z.ZodObject<Properties<UserCreateBot
 export function UserCreateCommunityInputSchema(): z.ZodObject<Properties<UserCreateCommunityInput>> {
   return z.object({
     avatarUrl: z.string().nullish(),
-    cluster: NetworkClusterSchema,
     description: z.string().nullish(),
     discordUrl: z.string().nullish(),
     githubUrl: z.string().nullish(),

--- a/libs/sdk/src/graphql/feature-community.graphql
+++ b/libs/sdk/src/graphql/feature-community.graphql
@@ -12,7 +12,6 @@ fragment CommunityDetails on Community {
   twitterUrl
   telegramUrl
   updatedAt
-  cluster
 }
 
 query adminFindManyCommunity($input: AdminFindManyCommunityInput!) {

--- a/libs/web/community/feature/src/lib/admin-community-create.feature.tsx
+++ b/libs/web/community/feature/src/lib/admin-community-create.feature.tsx
@@ -1,16 +1,12 @@
-import { AdminCreateCommunityInput, NetworkCluster } from '@pubkey-link/sdk'
+import { AdminCreateCommunityInput } from '@pubkey-link/sdk'
 import { useAdminFindManyCommunity } from '@pubkey-link/web-community-data-access'
 import { AdminCommunityUiCreateForm } from '@pubkey-link/web-community-ui'
-import { useUserGetEnabledNetworkClusters } from '@pubkey-link/web-network-data-access'
-import { toastError, UiAlert, UiBack, UiCard, UiLoader, UiPage } from '@pubkey-ui/core'
-import { useMemo } from 'react'
+import { toastError, UiBack, UiCard, UiPage } from '@pubkey-ui/core'
 import { useNavigate } from 'react-router-dom'
 
 export function AdminCommunityCreateFeature() {
   const navigate = useNavigate()
   const { createCommunity } = useAdminFindManyCommunity()
-  const clusterQuery = useUserGetEnabledNetworkClusters()
-  const clusters: NetworkCluster[] = useMemo(() => clusterQuery?.data?.clusters ?? [], [clusterQuery.data])
 
   async function submit(input: AdminCreateCommunityInput) {
     return createCommunity(input)
@@ -28,13 +24,7 @@ export function AdminCommunityCreateFeature() {
   return (
     <UiPage leftAction={<UiBack />} title="Create Community">
       <UiCard>
-        {clusterQuery.isLoading ? (
-          <UiLoader />
-        ) : clusters.length ? (
-          <AdminCommunityUiCreateForm clusters={clusters} submit={submit} />
-        ) : (
-          <UiAlert message="No clusters enabled" />
-        )}
+        <AdminCommunityUiCreateForm submit={submit} />
       </UiCard>
     </UiPage>
   )

--- a/libs/web/community/feature/src/lib/user-community-create.feature.tsx
+++ b/libs/web/community/feature/src/lib/user-community-create.feature.tsx
@@ -1,16 +1,12 @@
-import { NetworkCluster, UserCreateCommunityInput } from '@pubkey-link/sdk'
+import { UserCreateCommunityInput } from '@pubkey-link/sdk'
 import { useUserFindManyCommunity } from '@pubkey-link/web-community-data-access'
 import { UserCommunityUiCreateForm } from '@pubkey-link/web-community-ui'
-import { useUserGetEnabledNetworkClusters } from '@pubkey-link/web-network-data-access'
-import { toastError, UiAlert, UiBack, UiCard, UiLoader, UiPage } from '@pubkey-ui/core'
-import { useMemo } from 'react'
+import { toastError, UiBack, UiCard, UiPage } from '@pubkey-ui/core'
 import { useNavigate } from 'react-router-dom'
 
 export function UserCommunityCreateFeature() {
   const navigate = useNavigate()
   const { createCommunity } = useUserFindManyCommunity()
-  const clusterQuery = useUserGetEnabledNetworkClusters()
-  const clusters: NetworkCluster[] = useMemo(() => clusterQuery?.data?.clusters ?? [], [clusterQuery.data])
 
   async function submit(input: UserCreateCommunityInput) {
     return createCommunity(input)
@@ -29,13 +25,7 @@ export function UserCommunityCreateFeature() {
   return (
     <UiPage leftAction={<UiBack />} title="Create Community">
       <UiCard>
-        {clusterQuery.isLoading ? (
-          <UiLoader />
-        ) : clusters.length ? (
-          <UserCommunityUiCreateForm clusters={clusters} submit={submit} />
-        ) : (
-          <UiAlert message="No clusters enabled" />
-        )}
+        <UserCommunityUiCreateForm submit={submit} />
       </UiCard>
     </UiPage>
   )

--- a/libs/web/community/feature/src/lib/user-community-detail.feature.tsx
+++ b/libs/web/community/feature/src/lib/user-community-detail.feature.tsx
@@ -2,7 +2,6 @@ import { Badge, Group } from '@mantine/core'
 import { useUserFindOneCommunity } from '@pubkey-link/web-community-data-access'
 import { CommunityUiAdminIcon, CommunityUiItem } from '@pubkey-link/web-community-ui'
 import { AppUiDebugModal } from '@pubkey-link/web-core-ui'
-import { NetworkUiClusterBadge } from '@pubkey-link/web-network-ui'
 import { UiBack, UiContainer, UiError, UiGroup, UiLoader, UiStack } from '@pubkey-ui/core'
 import { useParams } from 'react-router-dom'
 import { CommunityDashboardMemberCardRoles } from './community-dashboard-member-card-roles'
@@ -38,7 +37,6 @@ export function UserCommunityDetailFeature() {
           <Group>
             <CommunityUiAdminIcon community={item} />
             <AppUiDebugModal data={{ item, communityAdmin, communityId, member }} />
-            <NetworkUiClusterBadge cluster={item.cluster} />
           </Group>
         </UiGroup>
         {member?.admin ? (

--- a/libs/web/community/ui/src/lib/admin-community-ui-create-form.tsx
+++ b/libs/web/community/ui/src/lib/admin-community-ui-create-form.tsx
@@ -1,18 +1,13 @@
 import { Button, Group } from '@mantine/core'
-import { AdminCreateCommunityInput, NetworkCluster } from '@pubkey-link/sdk'
-import { formFieldSelect, formFieldText, UiForm, UiFormField } from '@pubkey-ui/core'
-import { useDefaultFormCluster } from './use-default-form-cluster'
+import { AdminCreateCommunityInput } from '@pubkey-link/sdk'
+import { formFieldText, UiForm, UiFormField } from '@pubkey-ui/core'
 
 export function AdminCommunityUiCreateForm({
-  clusters = [],
   submit,
 }: {
-  clusters: NetworkCluster[]
   submit: (res: AdminCreateCommunityInput) => Promise<boolean>
 }) {
-  const cluster = useDefaultFormCluster(clusters)
   const model: AdminCreateCommunityInput = {
-    cluster,
     avatarUrl: '',
     description: '',
     discordUrl: '',
@@ -24,11 +19,6 @@ export function AdminCommunityUiCreateForm({
   }
 
   const fields: UiFormField<AdminCreateCommunityInput>[] = [
-    formFieldSelect('cluster', {
-      label: 'Cluster',
-      required: true,
-      options: clusters?.map((value) => ({ value, label: value })),
-    }),
     formFieldText('name', { label: 'Name', required: true }),
     formFieldText('description', { label: 'Description' }),
     formFieldText('avatarUrl', { label: 'Avatar Url' }),

--- a/libs/web/community/ui/src/lib/user-community-ui-create-form.tsx
+++ b/libs/web/community/ui/src/lib/user-community-ui-create-form.tsx
@@ -1,18 +1,9 @@
 import { Button, Group } from '@mantine/core'
-import { NetworkCluster, UserCreateCommunityInput } from '@pubkey-link/sdk'
-import { formFieldSelect, formFieldText, UiForm, UiFormField } from '@pubkey-ui/core'
-import { useDefaultFormCluster } from './use-default-form-cluster'
+import { UserCreateCommunityInput } from '@pubkey-link/sdk'
+import { formFieldText, UiForm, UiFormField } from '@pubkey-ui/core'
 
-export function UserCommunityUiCreateForm({
-  clusters = [],
-  submit,
-}: {
-  clusters: NetworkCluster[]
-  submit: (res: UserCreateCommunityInput) => Promise<boolean>
-}) {
-  const cluster = useDefaultFormCluster(clusters)
+export function UserCommunityUiCreateForm({ submit }: { submit: (res: UserCreateCommunityInput) => Promise<boolean> }) {
   const model: UserCreateCommunityInput = {
-    cluster,
     avatarUrl: '',
     description: '',
     discordUrl: '',
@@ -24,11 +15,6 @@ export function UserCommunityUiCreateForm({
   }
 
   const fields: UiFormField<UserCreateCommunityInput>[] = [
-    formFieldSelect('cluster', {
-      label: 'Cluster',
-      required: true,
-      options: clusters?.map((value) => ({ value, label: value })),
-    }),
     formFieldText('name', { label: 'Name', required: true }),
     formFieldText('description', { label: 'Description' }),
     formFieldText('avatarUrl', { label: 'Avatar Url' }),

--- a/libs/web/dev/feature/src/lib/dev-condition-wizard-detail.tsx
+++ b/libs/web/dev/feature/src/lib/dev-condition-wizard-detail.tsx
@@ -1,8 +1,7 @@
 import { Accordion, Grid, NavLink } from '@mantine/core'
-import { Community, NetworkToken, Role } from '@pubkey-link/sdk'
+import { Community, Role } from '@pubkey-link/sdk'
 import { useAdminFindOneCommunity } from '@pubkey-link/web-community-data-access'
 import { CommunityUiItem } from '@pubkey-link/web-community-ui'
-import { useAdminFindManyNetworkToken } from '@pubkey-link/web-network-token-data-access'
 import { useAdminFindManyRole, useUserFindOneRole } from '@pubkey-link/web-role-data-access'
 import {
   RoleConditionUiCreateWizard,
@@ -40,10 +39,9 @@ export function DevConditionWizardDetail() {
 
 export function DevConditionWizardDetailGrid({ community, roles }: { community: Community; roles: Role[] }) {
   const { pathname } = useLocation()
-  const { items } = useAdminFindManyNetworkToken({ cluster: community.cluster })
   const routes = useRoutes([
     { path: '', element: <UiInfo message="Select a role to continue" /> },
-    { path: ':roleId', element: <RoleDetails community={community} roles={roles ?? []} tokens={items} /> },
+    { path: ':roleId', element: <RoleDetails community={community} /> },
   ])
 
   return (
@@ -69,7 +67,7 @@ export function DevConditionWizardDetailGrid({ community, roles }: { community: 
   )
 }
 
-function RoleDetails({ community, roles, tokens }: { community: Community; roles: Role[]; tokens: NetworkToken[] }) {
+function RoleDetails({ community }: { community: Community }) {
   const { roleId } = useParams() as { roleId: string }
   const { item: role, query } = useUserFindOneRole({ roleId })
 
@@ -86,7 +84,7 @@ function RoleDetails({ community, roles, tokens }: { community: Community; roles
       <UiCard>
         <UiCardTitle>Conditions</UiCardTitle>
       </UiCard>
-      <RoleConditionUiCreateWizard role={role} community={community} tokens={tokens} />
+      <RoleConditionUiCreateWizard role={role} community={community} />
       {role.conditions?.length ? (
         <Accordion multiple variant="separated">
           {role.conditions.map((condition) => (

--- a/libs/web/network-token/ui/src/lib/network-token-ui-item.tsx
+++ b/libs/web/network-token/ui/src/lib/network-token-ui-item.tsx
@@ -40,9 +40,7 @@ export function NetworkTokenUiItem({
               {networkToken?.name}
             </Text>
             <NetworkTokenUiTypeBadge type={networkToken.type} />
-            {networkToken.cluster === NetworkCluster.SolanaMainnet ? null : (
-              <NetworkUiClusterBadge cluster={networkToken.cluster} size="xs" style={{ textTransform: 'inherit' }} />
-            )}
+            <NetworkUiClusterBadge cluster={networkToken.cluster} size="xs" style={{ textTransform: 'inherit' }} />
           </Group>
           {to ? (
             account

--- a/libs/web/network/ui/src/lib/network-ui-select-cluster.tsx
+++ b/libs/web/network/ui/src/lib/network-ui-select-cluster.tsx
@@ -4,9 +4,11 @@ import { UiSelectEnum } from '@pubkey-ui/core'
 export function NetworkUiSelectCluster({
   value,
   setValue,
+  options = getEnumOptions(NetworkCluster),
 }: {
   value: NetworkCluster | undefined
   setValue: (role: NetworkCluster) => void
+  options?: { label: string; value: NetworkCluster }[]
 }) {
   return (
     <UiSelectEnum<NetworkCluster>
@@ -16,7 +18,7 @@ export function NetworkUiSelectCluster({
       clearable
       placeholder="Filter by cluster"
       options={[
-        ...getEnumOptions(NetworkCluster).map(({ label, value }) => ({
+        ...options.map(({ label, value }) => ({
           value,
           label: label.replace('Solana', 'Solana '),
         })),

--- a/libs/web/role/feature/src/lib/user-role-condition-list.feature.tsx
+++ b/libs/web/role/feature/src/lib/user-role-condition-list.feature.tsx
@@ -1,10 +1,10 @@
 import { Accordion, Text } from '@mantine/core'
-import { Community, NetworkToken, Role } from '@pubkey-link/sdk'
+import { Community, Role } from '@pubkey-link/sdk'
 
 import { RoleConditionUiItem, RoleConditionUiPanel } from '@pubkey-link/web-role-ui'
 import { UiStack } from '@pubkey-ui/core'
 
-export function UserRoleConditionListFeature(props: { role: Role; community: Community; tokens: NetworkToken[] }) {
+export function UserRoleConditionListFeature(props: { role: Role; community: Community }) {
   const conditions = props.role.conditions ?? []
   return (
     <UiStack>

--- a/libs/web/role/feature/src/lib/user-role-detail-conditions.tab.tsx
+++ b/libs/web/role/feature/src/lib/user-role-detail-conditions.tab.tsx
@@ -1,13 +1,11 @@
 import { Community, Role } from '@pubkey-link/sdk'
-import { useUserFindManyNetworkToken } from '@pubkey-link/web-network-token-data-access'
 import { RoleConditionUiCreateWizard } from '@pubkey-link/web-role-ui'
 import { UserRoleConditionListFeature } from './user-role-condition-list.feature'
 
 export function UserRoleDetailConditionsTab({ community, role }: { community: Community; role: Role }) {
-  const { items } = useUserFindManyNetworkToken({ cluster: community.cluster, limit: 100 })
   return role.conditions?.length ? (
-    <UserRoleConditionListFeature role={role} community={community} tokens={items ?? []} />
+    <UserRoleConditionListFeature role={role} community={community} />
   ) : (
-    <RoleConditionUiCreateWizard role={role} community={community} tokens={items ?? []} />
+    <RoleConditionUiCreateWizard role={role} community={community} />
   )
 }

--- a/libs/web/role/feature/src/lib/user-role-detail.feature.tsx
+++ b/libs/web/role/feature/src/lib/user-role-detail.feature.tsx
@@ -2,7 +2,6 @@ import { Group, Text } from '@mantine/core'
 import { Community } from '@pubkey-link/sdk'
 import { useUserFindOneBot } from '@pubkey-link/web-bot-data-access'
 import { AppUiDebugModal } from '@pubkey-link/web-core-ui'
-import { useUserFindManyNetworkToken } from '@pubkey-link/web-network-token-data-access'
 import { useUserFindOneRole } from '@pubkey-link/web-role-data-access'
 import { RoleConditionUiAddButton, RoleUiItem } from '@pubkey-link/web-role-ui'
 import { UiAnchor, UiBack, UiCard, UiCardTitle, UiError, UiGroup, UiLoader, UiStack, UiWarning } from '@pubkey-ui/core'
@@ -14,7 +13,6 @@ import { UserRoleDetailSettingsTab } from './user-role-detail-settings.tab'
 export function UserRoleDetailFeature({ community }: { community: Community }) {
   const { roleId } = useParams<{ roleId: string }>() as { roleId: string }
   const { item, query } = useUserFindOneRole({ roleId })
-  const { items: tokens } = useUserFindManyNetworkToken({ cluster: community.cluster, limit: 100 })
   const { query: botQuery, item: bot } = useUserFindOneBot({ communityId: community.id })
 
   const isLoading = query.isLoading || botQuery.isLoading
@@ -35,7 +33,7 @@ export function UserRoleDetailFeature({ community }: { community: Community }) {
           title={
             <UiGroup>
               <UiCardTitle>Conditions</UiCardTitle>
-              <RoleConditionUiAddButton community={community} tokens={tokens} role={item} />
+              <RoleConditionUiAddButton community={community} role={item} />
             </UiGroup>
           }
         >

--- a/libs/web/role/ui/src/lib/role-condition-ui-add-button.tsx
+++ b/libs/web/role/ui/src/lib/role-condition-ui-add-button.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@mantine/core'
 import { modals } from '@mantine/modals'
-import { Community, NetworkToken, Role } from '@pubkey-link/sdk'
+import { Community, Role } from '@pubkey-link/sdk'
 import { IconPlus } from '@tabler/icons-react'
 import { RoleConditionUiCreateWizard } from './role-condition-ui-create-wizard'
 
-export function RoleConditionUiAddButton(props: { role: Role; community: Community; tokens: NetworkToken[] }) {
+export function RoleConditionUiAddButton(props: { role: Role; community: Community }) {
   return (
     <Button
       size="xs"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,7 +71,7 @@ model Community {
   featured    Boolean           @default(false)
   members     CommunityMember[]
   roles       Role[]
-  cluster     NetworkCluster
+  cluster     NetworkCluster? // This field is deprecated and will be removed in a future version
   bot         Bot?
   logs        Log[]
 


### PR DESCRIPTION
Previously, you could only link 1 community to 1 cluster, and add roles/conditions around that.

We didn't use this property for any of the roles/conditions logic, but it did limit the UI.

This reworks the UI and presents a cluster selector in the Role/Conditions wizard, thus allowing us to deprecate this field and remove the limitations.

In 1 community you can now add roles/conditions for tokens on any cluster that is configured.
