### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -19,14 +19,14 @@ jobs:
       packages: write
 
     steps:
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,12 +34,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker (dev)
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v6.9.0
         if: github.ref == 'refs/heads/dev'
         with:
           context: .
@@ -47,7 +47,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker (main)
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v6.9.0
         if: github.ref == 'refs/heads/main'
         with:
           context: .
@@ -55,7 +55,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker (Manual)
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v6.9.0
         if: github.event_name == 'workflow_dispatch'
         with:
           context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   main:
     name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.13.0
+    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.15.0
     with:
       node-version: 20.10.0
       pnpm-version: 9.3.0
@@ -33,7 +33,7 @@ jobs:
 
   agents:
     name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.13.0
+    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.15.0
     with:
       node-version: 20.10.0
       pnpm-version: 9.3.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,18 +45,18 @@ jobs:
         ports: ['6379:6379']
         options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 9.3.0
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.2.2
         name: Checkout [main]
         with:
           fetch-depth: 0
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4.1.2
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: '18'
       - run: pnpm install --frozen-lockfile --prefer-frozen-lockfile

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.1.2](https://github.com/actions/cache/releases/tag/v4.1.2)** on 2024-10-22T13:08:44Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.9.0](https://github.com/docker/build-push-action/releases/tag/v6.9.0)** on 2024-09-30T09:51:48Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v5.5.1](https://github.com/docker/metadata-action/releases/tag/v5.5.1)** on 2024-01-31T13:07:55Z
* **[nrwl/ci](https://github.com/nrwl/ci)** published a new release **[v0.15.0](https://github.com/nrwl/ci/releases/tag/v0.15.0)** on 2024-06-11T12:55:15Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.1.0](https://github.com/actions/setup-node/releases/tag/v4.1.0)** on 2024-10-24T13:51:16Z
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release **[v4.0.0](https://github.com/pnpm/action-setup/releases/tag/v4.0.0)** on 2024-05-07T13:19:01Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.3.0](https://github.com/docker/login-action/releases/tag/v3.3.0)** on 2024-07-22T09:07:15Z
