### PR TITLE
feat: simplify community create inputs and screens

### DIFF
--- a/api-schema.graphql
+++ b/api-schema.graphql
@@ -15,14 +15,7 @@ input AdminCreateBotInput {
 }
 
 input AdminCreateCommunityInput {
-  avatarUrl: String
-  description: String
-  discordUrl: String
-  githubUrl: String
   name: String!
-  telegramUrl: String
-  twitterUrl: String
-  websiteUrl: String
 }
 
 input AdminCreateIdentityInput {
@@ -815,14 +808,7 @@ input UserCreateBotInput {
 }
 
 input UserCreateCommunityInput {
-  avatarUrl: String
-  description: String
-  discordUrl: String
-  githubUrl: String
   name: String!
-  telegramUrl: String
-  twitterUrl: String
-  websiteUrl: String
 }
 
 input UserCreateRoleConditionInput {

--- a/libs/api/community/data-access/src/lib/dto/admin-create-community.input.ts
+++ b/libs/api/community/data-access/src/lib/dto/admin-create-community.input.ts
@@ -4,18 +4,4 @@ import { Field, InputType } from '@nestjs/graphql'
 export class AdminCreateCommunityInput {
   @Field()
   name!: string
-  @Field({ nullable: true })
-  avatarUrl?: string
-  @Field({ nullable: true })
-  description?: string
-  @Field({ nullable: true })
-  websiteUrl?: string
-  @Field({ nullable: true })
-  discordUrl?: string
-  @Field({ nullable: true })
-  githubUrl?: string
-  @Field({ nullable: true })
-  twitterUrl?: string
-  @Field({ nullable: true })
-  telegramUrl?: string
 }

--- a/libs/api/community/data-access/src/lib/dto/user-create-community.input.ts
+++ b/libs/api/community/data-access/src/lib/dto/user-create-community.input.ts
@@ -4,18 +4,4 @@ import { Field, InputType } from '@nestjs/graphql'
 export class UserCreateCommunityInput {
   @Field()
   name!: string
-  @Field({ nullable: true })
-  avatarUrl?: string
-  @Field({ nullable: true })
-  description?: string
-  @Field({ nullable: true })
-  websiteUrl?: string
-  @Field({ nullable: true })
-  discordUrl?: string
-  @Field({ nullable: true })
-  githubUrl?: string
-  @Field({ nullable: true })
-  twitterUrl?: string
-  @Field({ nullable: true })
-  telegramUrl?: string
 }

--- a/libs/sdk/src/generated/graphql-sdk.ts
+++ b/libs/sdk/src/generated/graphql-sdk.ts
@@ -37,14 +37,7 @@ export type AdminCreateBotInput = {
 }
 
 export type AdminCreateCommunityInput = {
-  avatarUrl?: InputMaybe<Scalars['String']['input']>
-  description?: InputMaybe<Scalars['String']['input']>
-  discordUrl?: InputMaybe<Scalars['String']['input']>
-  githubUrl?: InputMaybe<Scalars['String']['input']>
   name: Scalars['String']['input']
-  telegramUrl?: InputMaybe<Scalars['String']['input']>
-  twitterUrl?: InputMaybe<Scalars['String']['input']>
-  websiteUrl?: InputMaybe<Scalars['String']['input']>
 }
 
 export type AdminCreateIdentityInput = {
@@ -1401,14 +1394,7 @@ export type UserCreateBotInput = {
 }
 
 export type UserCreateCommunityInput = {
-  avatarUrl?: InputMaybe<Scalars['String']['input']>
-  description?: InputMaybe<Scalars['String']['input']>
-  discordUrl?: InputMaybe<Scalars['String']['input']>
-  githubUrl?: InputMaybe<Scalars['String']['input']>
   name: Scalars['String']['input']
-  telegramUrl?: InputMaybe<Scalars['String']['input']>
-  twitterUrl?: InputMaybe<Scalars['String']['input']>
-  websiteUrl?: InputMaybe<Scalars['String']['input']>
 }
 
 export type UserCreateRoleConditionInput = {
@@ -13337,14 +13323,7 @@ export function AdminCreateBotInputSchema(): z.ZodObject<Properties<AdminCreateB
 
 export function AdminCreateCommunityInputSchema(): z.ZodObject<Properties<AdminCreateCommunityInput>> {
   return z.object({
-    avatarUrl: z.string().nullish(),
-    description: z.string().nullish(),
-    discordUrl: z.string().nullish(),
-    githubUrl: z.string().nullish(),
     name: z.string(),
-    telegramUrl: z.string().nullish(),
-    twitterUrl: z.string().nullish(),
-    websiteUrl: z.string().nullish(),
   })
 }
 
@@ -13598,14 +13577,7 @@ export function UserCreateBotInputSchema(): z.ZodObject<Properties<UserCreateBot
 
 export function UserCreateCommunityInputSchema(): z.ZodObject<Properties<UserCreateCommunityInput>> {
   return z.object({
-    avatarUrl: z.string().nullish(),
-    description: z.string().nullish(),
-    discordUrl: z.string().nullish(),
-    githubUrl: z.string().nullish(),
     name: z.string(),
-    telegramUrl: z.string().nullish(),
-    twitterUrl: z.string().nullish(),
-    websiteUrl: z.string().nullish(),
   })
 }
 

--- a/libs/web/community/feature/src/lib/admin-community-detail-overview.tab.tsx
+++ b/libs/web/community/feature/src/lib/admin-community-detail-overview.tab.tsx
@@ -1,5 +1,5 @@
 import { useAdminFindOneCommunity } from '@pubkey-link/web-community-data-access'
-import { UiCard, UiDebug, UiError, UiLoader } from '@pubkey-ui/core'
+import { UiDebug, UiError, UiLoader } from '@pubkey-ui/core'
 
 export function AdminCommunityDetailOverviewTab({ communityId }: { communityId: string }) {
   const { item, query } = useAdminFindOneCommunity({ communityId })
@@ -11,9 +11,5 @@ export function AdminCommunityDetailOverviewTab({ communityId }: { communityId: 
     return <UiError message="Community not found." />
   }
 
-  return (
-    <UiCard>
-      <UiDebug data={item} open />
-    </UiCard>
-  )
+  return <UiDebug data={item} open />
 }

--- a/libs/web/community/feature/src/lib/admin-community-detail.feature.tsx
+++ b/libs/web/community/feature/src/lib/admin-community-detail.feature.tsx
@@ -1,4 +1,4 @@
-import { Group } from '@mantine/core'
+import { Button, Group } from '@mantine/core'
 import { AppFeature } from '@pubkey-link/sdk'
 import { AdminBotFeature } from '@pubkey-link/web-bot-feature'
 import { useAdminFindOneCommunity } from '@pubkey-link/web-community-data-access'
@@ -7,8 +7,18 @@ import { CommunityUiItem } from '@pubkey-link/web-community-ui'
 import { useAppConfig } from '@pubkey-link/web-core-data-access'
 import { AdminLogFeature } from '@pubkey-link/web-log-feature'
 import { AdminRoleFeature } from '@pubkey-link/web-role-feature'
-import { UiBack, UiDebugModal, UiError, UiLoader, UiPage, UiTabRoute, UiTabRoutes } from '@pubkey-ui/core'
-import { useParams } from 'react-router-dom'
+import {
+  UiAlert,
+  UiBack,
+  UiDebugModal,
+  UiError,
+  UiLoader,
+  UiPage,
+  UiStack,
+  UiTabRoute,
+  UiTabRoutes,
+} from '@pubkey-ui/core'
+import { Link, useParams } from 'react-router-dom'
 import { AdminCommunityDetailOverviewTab } from './admin-community-detail-overview.tab'
 import { AdminCommunityDetailSettingsTab } from './admin-community-detail-settings.tab'
 
@@ -31,7 +41,12 @@ export function AdminCommunityDetailFeature() {
     {
       path: 'overview',
       label: 'Overview',
-      element: <AdminCommunityDetailOverviewTab communityId={communityId} />,
+      element: (
+        <UiStack>
+          <UiAlert message="This section is for admin operations and debugging. Use the Manage Community option above to adjust its settings" />
+          <AdminCommunityDetailOverviewTab communityId={communityId} />
+        </UiStack>
+      ),
     },
     {
       path: 'roles',
@@ -68,6 +83,9 @@ export function AdminCommunityDetailFeature() {
       rightAction={
         <Group>
           <UiDebugModal data={item} />
+          <Button component={Link} to={item.viewUrl} variant="light">
+            Manage Community
+          </Button>
         </Group>
       }
     >

--- a/libs/web/community/ui/src/lib/admin-community-ui-create-form.tsx
+++ b/libs/web/community/ui/src/lib/admin-community-ui-create-form.tsx
@@ -8,26 +8,10 @@ export function AdminCommunityUiCreateForm({
   submit: (res: AdminCreateCommunityInput) => Promise<boolean>
 }) {
   const model: AdminCreateCommunityInput = {
-    avatarUrl: '',
-    description: '',
-    discordUrl: '',
-    githubUrl: '',
     name: '',
-    telegramUrl: '',
-    twitterUrl: '',
-    websiteUrl: '',
   }
 
-  const fields: UiFormField<AdminCreateCommunityInput>[] = [
-    formFieldText('name', { label: 'Name', required: true }),
-    formFieldText('description', { label: 'Description' }),
-    formFieldText('avatarUrl', { label: 'Avatar Url' }),
-    formFieldText('discordUrl', { label: 'Discord Url' }),
-    formFieldText('githubUrl', { label: 'Github Url' }),
-    formFieldText('telegramUrl', { label: 'Telegram Url' }),
-    formFieldText('twitterUrl', { label: 'Twitter Url' }),
-    formFieldText('websiteUrl', { label: 'Website Url' }),
-  ]
+  const fields: UiFormField<AdminCreateCommunityInput>[] = [formFieldText('name', { label: 'Name', required: true })]
 
   return (
     <UiForm model={model} fields={fields} submit={(res) => submit(res as AdminCreateCommunityInput)}>

--- a/libs/web/community/ui/src/lib/user-community-ui-create-form.tsx
+++ b/libs/web/community/ui/src/lib/user-community-ui-create-form.tsx
@@ -4,26 +4,10 @@ import { formFieldText, UiForm, UiFormField } from '@pubkey-ui/core'
 
 export function UserCommunityUiCreateForm({ submit }: { submit: (res: UserCreateCommunityInput) => Promise<boolean> }) {
   const model: UserCreateCommunityInput = {
-    avatarUrl: '',
-    description: '',
-    discordUrl: '',
-    githubUrl: '',
     name: '',
-    telegramUrl: '',
-    twitterUrl: '',
-    websiteUrl: '',
   }
 
-  const fields: UiFormField<UserCreateCommunityInput>[] = [
-    formFieldText('name', { label: 'Name', required: true }),
-    formFieldText('description', { label: 'Description' }),
-    formFieldText('avatarUrl', { label: 'Avatar Url' }),
-    formFieldText('discordUrl', { label: 'Discord Url' }),
-    formFieldText('githubUrl', { label: 'Github Url' }),
-    formFieldText('telegramUrl', { label: 'Telegram Url' }),
-    formFieldText('twitterUrl', { label: 'Twitter Url' }),
-    formFieldText('websiteUrl', { label: 'Website Url' }),
-  ]
+  const fields: UiFormField<UserCreateCommunityInput>[] = [formFieldText('name', { label: 'Name', required: true })]
 
   return (
     <UiForm model={model} fields={fields} submit={(res) => submit(res as UserCreateCommunityInput)}>


### PR DESCRIPTION
The community create screens for admin and user now only asks for a 'name' field, the rest of the options can be modified with the 'update' operations.