### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -39,7 +39,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker (dev)
-        uses: docker/build-push-action@v6.10.0
+        uses: docker/build-push-action@v6.11.0
         if: github.ref == 'refs/heads/dev'
         with:
           context: .
@@ -47,7 +47,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker (main)
-        uses: docker/build-push-action@v6.10.0
+        uses: docker/build-push-action@v6.11.0
         if: github.ref == 'refs/heads/main'
         with:
           context: .
@@ -55,7 +55,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker (Manual)
-        uses: docker/build-push-action@v6.10.0
+        uses: docker/build-push-action@v6.11.0
         if: github.event_name == 'workflow_dispatch'
         with:
           context: .


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.11.0](https://github.com/docker/build-push-action/releases/tag/v6.11.0)** on 2025-01-08T09:17:44Z
