### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -39,7 +39,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker (dev)
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@v6.14.0
         if: github.ref == 'refs/heads/dev'
         with:
           context: .
@@ -47,7 +47,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker (main)
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@v6.14.0
         if: github.ref == 'refs/heads/main'
         with:
           context: .
@@ -55,7 +55,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker (Manual)
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@v6.14.0
         if: github.event_name == 'workflow_dispatch'
         with:
           context: .

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,7 @@ jobs:
         name: Checkout [main]
         with:
           fetch-depth: 0
-      - uses: actions/cache@v4.2.0
+      - uses: actions/cache@v4.2.1
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.14.0](https://github.com/docker/build-push-action/releases/tag/v6.14.0)** on 2025-02-19T15:23:54Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.1](https://github.com/actions/cache/releases/tag/v4.2.1)** on 2025-02-18T17:44:12Z
