### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - uses: actions/setup-node@v4.3.0
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version: '18'
       - run: pnpm install --frozen-lockfile --prefer-frozen-lockfile


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.4.0](https://github.com/actions/setup-node/releases/tag/v4.4.0)** on 2025-04-14T02:55:06Z
