### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -39,7 +39,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker (dev)
-        uses: docker/build-push-action@v6.15.0
+        uses: docker/build-push-action@v6.16.0
         if: github.ref == 'refs/heads/dev'
         with:
           context: .
@@ -47,7 +47,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker (main)
-        uses: docker/build-push-action@v6.15.0
+        uses: docker/build-push-action@v6.16.0
         if: github.ref == 'refs/heads/main'
         with:
           context: .
@@ -55,7 +55,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker (Manual)
-        uses: docker/build-push-action@v6.15.0
+        uses: docker/build-push-action@v6.16.0
         if: github.event_name == 'workflow_dispatch'
         with:
           context: .

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - uses: actions/setup-node@v4.3.0
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version: '18'
       - run: pnpm install --frozen-lockfile --prefer-frozen-lockfile


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.4.0](https://github.com/actions/setup-node/releases/tag/v4.4.0)** on 2025-04-14T02:55:06Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.16.0](https://github.com/docker/build-push-action/releases/tag/v6.16.0)** on 2025-04-24T14:18:49Z
