### PR TITLE
fix: ensure to limit deleting of old network assets to tokens that we're resolving

### DIFF
--- a/libs/api/network-asset/data-access/src/lib/api-network-asset-sync.service.ts
+++ b/libs/api/network-asset/data-access/src/lib/api-network-asset-sync.service.ts
@@ -209,7 +209,6 @@ export class ApiNetworkAssetSyncService {
       this.logger.error(`[${cluster}] syncIdentity: Error syncing assets for ${owner} on ${cluster}: ${error}`)
       throw error
     }
-    const assetIds = assets.map((a) => a.account)
 
     this.logger.verbose(`[${cluster}] syncIdentity: Resolved ${assets.length} assets for ${owner} on ${cluster}`)
     if (!assets.length) {
@@ -219,10 +218,13 @@ export class ApiNetworkAssetSyncService {
     // Upsert the assets
     await this.upsertAssets({ cluster, assets, linkIdentity: true })
 
-    // Remove any assets that are not in the list
+    // Remove any assets that are in these groups and did not get resolved.
+    const groups = tokens.map((t) => t.account)
+    const assetIds = assets.map((a) => a.account)
     const removedIds = await this.core.data.networkAsset.deleteMany({
       where: {
         owner,
+        group: { in: groups },
         NOT: { account: { in: assetIds } },
       },
     })


### PR DESCRIPTION
This patch fixes an issue where the logic would delete assets that were added using another method (eg, cached tokens).

The fix makes sure to only delete tokens from groups (mints/collections) that we're actually resolving. So assets from cached tokens will never be deleted through this logic.