### PR TITLE
fix: require filters before matching nft attributes

### DIFF
--- a/libs/api/role/data-access/src/lib/api-role-resolver.service.ts
+++ b/libs/api/role/data-access/src/lib/api-role-resolver.service.ts
@@ -351,7 +351,7 @@ export class ApiRoleResolverService {
 
   private getAssetAmount(condition: RoleCondition, assets: NetworkAsset[]) {
     const filtered =
-      condition.type === NetworkTokenType.NonFungible && Object.keys(condition.filters ?? {})
+      condition.type === NetworkTokenType.NonFungible && Object.keys(condition.filters ?? {}).length > 0
         ? assets
             .filter((assets) => !!Object.keys(assets.attributes ?? {})?.length)
             .filter((assets) =>


### PR DESCRIPTION
Check that a role condition has at least one filter before taking the attribute-based NFT matching path.

This prevents empty filter objects from being treated as active filters during asset amount resolution.